### PR TITLE
Bower Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Includes Font Awesome and Open Sans from a CDN.
 This is for LESS importing:
 
 ```css
-@makerstrap-bower-path: '../bower_components';
+
 @import 'bower_components/makerstrap/less/makerstrap';
+@makerstrap-bower-path: '../bower_components';
 
 ```
 


### PR DESCRIPTION
I don't think you can actually override `@makerstrap-bower-path` (for importing Bootstrap from a different location) the way things are currently set up.

**makerstrap.less**

``` css
@makerstrap-bower-path: '../bower_components';

// Bootstrap base

@import '@{makerstrap-bower-path}/bootstrap/less/bootstrap';
```

We want to make sure people can override (and use mixins from) Makerstrap + Bootstrap without editing them directly.
