### PR TITLE
Fix #24: Set border radius to 0

### DIFF
--- a/less/makerstrap.less
+++ b/less/makerstrap.less
@@ -26,14 +26,13 @@
 * Small mods, not worth their own files
 */
 
+@border-radius-base: 0;
+@border-radius-large: 0;
+@border-radius-small: 0;
+
 // This is for ugly button :active and :focus states.
 .tab-focus() {
   outline: none;
-}
-
-// Square buttons!
-.btn {
-  border-radius: 0;
 }
 
 // Yeah, don't know why this isn't applied...


### PR DESCRIPTION
I removed the border-radius from the btn and set border-radius to 0 so it's the default for everything. 
