### PR TITLE
Remove need to ever edit makerstrap files directly

### DIFF
--- a/less/makerstrap.less
+++ b/less/makerstrap.less
@@ -8,11 +8,6 @@
 
 @import '@{makerstrap-bower-path}/bootstrap/less/bootstrap';
 
-// Uncomment for Font Awesome
-// @import '@{makerstrap-bower-path}/font-awesome/less/font-awesome';
-// @fa-font-path: '@{makerstrap-bower-path}/font-awesome/fonts';
-
-
 /*********************************************************
 * Main Mod
 */


### PR DESCRIPTION
For example in `makerstrap.less` 

``` css
// Uncomment for Font Awesome
// @import '@{makerstrap-bower-path}/font-awesome/less/font-awesome';
// @fa-font-path: '@{makerstrap-bower-path}/font-awesome/fonts';
```

Makerstrap should typically exist as a read-only module in bower_components.
