### PR TITLE
URL color in jumbotron class is hard to read

### DIFF
--- a/less/jumbotron.less
+++ b/less/jumbotron.less
@@ -20,4 +20,8 @@
   h1, p {
     font-weight: 300;
   }
+  a {
+    color: white;
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
If you have a link on top of the green in the jumbotron class, it's blue and impossible to read.

http://i.imgur.com/EiSKGXG.png
