### PR TITLE
Add gzip compression to grunt build task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 bower_components/
 demo/compiled/demo.dev.css
+s3/
 tmp
 .DS_Store
 .idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,7 @@ module.exports = function(grunt) {
         mode: 'gzip'
       },
        files: [
-       {expand: true, src: ['dist/.css'], dest: 'dist/', ext: '.gz.css'}
+       {expand: true, src: ['dist/*.css'], dest: 's3/', ext: ' '}
        ]
      }
    }
@@ -60,6 +60,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-shell-spawn');
+  grunt.loadNpmTasks('grunt-contrib-compress');
 
   grunt.registerTask('default', ['less:development', 'shell:runServer', 'watch' ]);
   grunt.registerTask('build', ['less:build', 'compress']);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "grunt-contrib-less": "0.10.0",
     "grunt-contrib-watch": "0.5.3",
     "grunt-develop": "~0.3.0",
-    "grunt-shell-spawn": "~0.3.0"
+    "grunt-shell-spawn": "~0.3.0",
+    "grunt-contrib-compress": "~0.4.0"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
Since hosted files are being uploaded directly to s3, which does not apply any compression, we should be compressing them as much as possible.
