### PR TITLE
Style updates for navbars

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -13,3 +13,9 @@
 .navbar-inverse .navbar-toggle {
   color: @navbar-inverse-color;
 }
+.navbar-inverse {
+	font-weight: normal;
+	-webkit-font-smoothing:antialiased;
+	color: #FFF;
+	opacity: 1;
+}

--- a/less/variables.less
+++ b/less/variables.less
@@ -74,10 +74,11 @@
 // --------------------------------------------------
 @navbar-default-bg: white;
 @navbar-default-link-active-bg: lighten(#E3EAEE, 6%);
+@navbar-padding-horizontal: 15px;
 
 // Navbar Inverse
 // --------------------------------------------------
-@navbar-inverse-color:             white;
+@navbar-inverse-color:             #FFF;
 @navbar-inverse-bg:                @brand-secondary;
 @navbar-inverse-border:            darken(@navbar-inverse-bg, 6.5%);
 


### PR DESCRIPTION
Small style tweaks to navbars to bring them closer to webmaker.org

For all navbars:
- Nav items have `18px` of horizontal padding rather than `15px`

For `.navbar-inverse`, we need
- `font-weight: normal`, not light
- Webmaker.org has `-webkit-font-smoothing:antialised` applied
- default state (no hover) is #FFF with 100% opacity

Current:
![image](https://f.cloud.github.com/assets/1455535/2400059/c8cadbb0-aa05-11e3-88fc-257ceb8aee5a.png)

Intended:
![image](https://f.cloud.github.com/assets/1455535/2400064/d7d2f322-aa05-11e3-8a49-eb8a63e1a2d0.png)
