### PR TITLE
Update Colours

### DIFF
--- a/demo/js/styleguide.js
+++ b/demo/js/styleguide.js
@@ -142,10 +142,10 @@ angular.module('styleguide', ['ngRoute', 'ui.bootstrap', 'hljs'])
         hex: '#3fb58e',
         bootstrap: 'primary'
       },
-      // {
-      //   less: 'darkgreen',
-      //   hex: '#328f70'
-      // },
+       {
+         less: 'darkgreen',
+         hex: '#328f70'
+       },
       {
         less: 'navy',
         hex: '#013E5F',
@@ -179,10 +179,12 @@ angular.module('styleguide', ['ngRoute', 'ui.bootstrap', 'hljs'])
       }, {
         less: 'lightgrey',
         hex: '#e3eaee'
-      }, {
-        less: 'midgrey',
-        hex: '#ddd'
-      }, {
+      },
+      //{
+      //  less: 'midgrey',
+      //  hex: '#ddd'
+      // }, 
+      {
         less: 'white',
         hex: '#fff'
       }, {

--- a/less/variables.less
+++ b/less/variables.less
@@ -15,7 +15,7 @@
 @green: #3fb58e;
 @grey: #4d4e53;
 @lightgrey: #e3eaee;
-@midgrey: #ddd;
+@midgrey: #ddd; //depreciated
 @white: #fff;
 @black: #000;
 @navy: #013E5F;


### PR DESCRIPTION
Want to add the darker green from the styleguide: #328F70. Also, what do you think about eliminating midgrey, replacing with light grey? They are so similar. Where is midgrey currently being used?

Eventually I think we should update this with a secondary palette, like the colours we're using in /Explore.
