### PR TITLE
Automatic builds/upload to s3 with travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 bower_components/
 demo/compiled/demo.dev.css
+deploy/
 tmp
 .DS_Store
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: node_js
+node_js:
+- '0.10'
+branches:
+  only:
+  - master
+before_script:
+- npm install -g grunt-cli
+before_deploy:
+- echo "Deploying commit $TRAVIS_COMMIT"
+- grunt deploy
+deploy:
+  provider: s3
+  access_key_id:
+    secure: NPdvsjLekBIL+6npACOW6P/3s5sPn0L4Is6Nfis+2yquqvMBFcxonOCq1gZ/tE1NdGmajuFs42jLvhlQfVUDh4XWaB4Do020HDbMbl3Opre9A2w99eA07M0WuJXfc7pnN8PH8l68/FL0iDhf9BPS1812Eo08b8uKt2Jo7eYJWXk=
+  secret_access_key:
+    secure: T9acA19ScUZOWrS4dyiS8VLp9vYFnRgVXoL2J3QYEIZgC6/WFQ2tQKRhlLZaZVqfBN+ghs4H4FolmXTyB7vgISy8+KNoh/900//H1SBe1SZxh+X+IQCwt4U/Ail2ex/l7e25o4pHQ9PbHXb2QmXw0/ntd85OY8M4zTKgn0ChtjI=
+  bucket: stuff.webmaker.org
+  skip_cleanup: true
+  upload-dir: makerstrap
+  local-dir: deploy
+  on:
+    repo: mozilla/makerstrap
+    tags: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 module.exports = function(grunt) {
 
   grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
 
     less: {
       development: {
@@ -42,6 +43,21 @@ module.exports = function(grunt) {
           spawn: false
         }
       }
+    },
+
+    copy: {
+      latest: {
+        expand: true,
+        cwd: 'dist/',
+        src: '**/*',
+        dest: 'deploy/latest/'
+      },
+      version: {
+        expand: true,
+        cwd: 'dist/',
+        src: '**/*',
+        dest: 'deploy/v<%= pkg.version %>/'
+      }
     }
 
   });
@@ -49,8 +65,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-shell-spawn');
+  grunt.loadNpmTasks('grunt-contrib-copy');
 
   grunt.registerTask('default', ['less:development', 'shell:runServer', 'watch' ]);
   grunt.registerTask('build', ['less:build']);
+  grunt.registerTask('deploy', ['copy']);
 
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "grunt-contrib-less": "0.10.0",
     "grunt-contrib-watch": "0.5.3",
     "grunt-develop": "~0.3.0",
-    "grunt-shell-spawn": "~0.3.0"
+    "grunt-shell-spawn": "~0.3.0",
+    "grunt-contrib-copy": "^0.5.0"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
Right now I am manually uploading new tags of `dist/makerstrap.css` and `dist/makerstrap.complete.css` to s3, which is not ideal.

It would be great if we could do this automatically through travis, preferably with the ability to use legacy versions (1.0.0/makerstrap.css or something)
