### PR TITLE
Update links to hosted version of makerstrap in examples/docs

### DIFF
--- a/demo/views/docs.html
+++ b/demo/views/docs.html
@@ -14,7 +14,7 @@
           </tr>
           <tr>
             <td>Hosted</td>
-            <td><div hljs>https://stuff.webmaker.org/makerstrap/v{{version}}/makerstrap.complete.min.css</div></td>
+            <td><div hljs>https://stuff.webmaker.org/makerstrap/latest/makerstrap.complete.min.css</div></td>
           </tr>
           </table>
         </div>


### PR DESCRIPTION
Anything that has a link like this:

`<link href="https://s3-us-west-2.amazonaws.com/makerstrap/makerstrap.complete.min.css" rel="stylesheet">`

Needs to be updated to use our new automatically updated version on stuff.webmaker.org:

`<link href="https://stuff.webmaker.org/makerstrap/latest/makerstrap.complete.min.css" rel="stylesheet">`

Also, we should note that all versions are available at 

`https://stuff.webmaker.org/makerstrap/v{{version}}/makerstrap.complete.min.css`
