### PR TITLE
Add the secondary nav blue to the color palette

### DIFF
--- a/demo/js/styleguide.js
+++ b/demo/js/styleguide.js
@@ -150,6 +150,9 @@ angular.module('styleguide', ['ngRoute', 'ui.bootstrap', 'hljs'])
         less: 'navy',
         hex: '#013E5F',
         bootstrap: 'secondary'
+      },{
+        less: 'lightnavy',
+        hex: '#01527D',
       }, {
         less: 'blue',
         hex: '#27aae1',


### PR DESCRIPTION
Currently the dark blue is listed on color palette but not the slightly lighter blue. Should add #01527D
