### PR TITLE
Remove orange from color palette

### DIFF
--- a/demo/js/styleguide.js
+++ b/demo/js/styleguide.js
@@ -145,10 +145,12 @@ angular.module('styleguide', ['ngRoute', 'ui.bootstrap', 'hljs'])
         less: 'red',
         hex: '#c13832',
         bootstrap: 'danger'
-      }, {
-        less: 'orange',
-        hex: '#ee8950'
-      }, {
+      }, 
+      // {
+      //   less: 'orange',
+      //   hex: '#ee8950'
+      // }, 
+      {
         less: 'lightyellow',
         hex: '#fff2cc'
       },

--- a/less/variables.less
+++ b/less/variables.less
@@ -8,7 +8,7 @@
 @yellow: #ffcd36;
 @lightyellow: #fff2cc;
 @darkyellow: #eab514;
-@orange: #ee8950;
+@orange: #ee8950; //depreciated
 @darkgreen: #328f70;
 @blue: #27aae1;
 @red: #EB5D52; // I lightened and desaturated this a bit -k88


### PR DESCRIPTION
Remove #ee8950, orange, we're not really using this anywhere.